### PR TITLE
Add feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+name: Feature
+description: New capability or enhancement
+labels: ["feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Who has this problem?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this work? What does "done" look like?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CareQuality
+        - Directory
+        - Interop
+        - Precheck
+        - Observability
+        - Infra
+        - DevEx
+    validations:
+      required: true
+  - type: dropdown
+    id: customer-impact
+    attributes:
+      label: Customer Impact
+      options:
+        - None
+        - Low
+        - Medium
+        - High
+        - Critical
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Adds a YAML-based feature request issue template with fields for problem, proposed solution, area, and customer impact
- Creates the `.github/ISSUE_TEMPLATE/` directory for org-level default templates

## Test plan
- [ ] Verify template appears on the "New Issue" chooser for repos without their own templates
- [ ] Confirm all dropdowns and required fields render correctly